### PR TITLE
Fix 115

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Suggests:
     gplots,RMassBankData,
     xcms (>= 1.37.1),
     CAMERA,
-    ontoCAT,
     RUnit,
     enviPat
 Collate:

--- a/R/validateMassBank.R
+++ b/R/validateMassBank.R
@@ -19,12 +19,11 @@
 #' @export
 validate <- function(path, simple = TRUE) {
 
-    requireNamespace("ontoCAT",quietly=TRUE)
 	requireNamespace("RUnit",quietly=TRUE)
 
 	# Is the argument a directory?
 	# If yes, list the files
-	RMassBank.env$Instrument_List <- .getInstruments()
+	RMassBank.env$Instrument_List <- "NO_INSTRUMENT_LIST_AFTER_ONTOCAT_REMOVAL"
 	RMassBank.env$testnumber <- 1
 	if(file.info(path[1])$isdir){
 	    Files <- list.files(path = path,
@@ -90,67 +89,67 @@ validate <- function(path, simple = TRUE) {
 	print(paste("Report for the file(s) finished"))
 }
 
-# This function checks if an .obo-file is readable for ontoCAT
-.isOboReadable <- function(filename){
+## # This function checks if an .obo-file is readable for ontoCAT
+## .isOboReadable <- function(filename){
 
-	# getOntology() has a problem with reading relative Windows paths(it wants an URI),
-	# so the path has to be made absolute
-	# I reckon this should work under Linux without doing that
-	ont <- ontoCAT::getOntology(normalizePath(filename))
-	if(is.null(ontoCAT::getOntologyAccession(ont))){
-		return(FALSE)
-	}
-	return(TRUE)
-}
+## 	# getOntology() has a problem with reading relative Windows paths(it wants an URI),
+## 	# so the path has to be made absolute
+## 	# I reckon this should work under Linux without doing that
+## 	ont <- ontoCAT::getOntology(normalizePath(filename))
+## 	if(is.null(ontoCAT::getOntologyAccession(ont))){
+## 		return(FALSE)
+## 	}
+## 	return(TRUE)
+## }
 
-# This function downloads the psi-ms.obo-ontology so we can get the allowed instrument-names
-# This is a _temporary_ fix until I find out why getOntology() doesn't work when there are "import:"-lines in the .obo-file
-# Until then I will simply remove them, because we don't need the imported ontologies
-.downloadPsiObo <- function(){
-		connPsiObo <- url("http://psidev.cvs.sourceforge.net/viewvc/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo")
-		oboFile <- readLines(connPsiObo)
-		close(connPsiObo)
-		oboFile <- oboFile[-grep("import:",oboFile)] 
-		connLocal <- file("psi-ms.obo")
-		writeLines(oboFile,connLocal)
-		close(connLocal)
-}
+## # This function downloads the psi-ms.obo-ontology so we can get the allowed instrument-names
+## # This is a _temporary_ fix until I find out why getOntology() doesn't work when there are "import:"-lines in the .obo-file
+## # Until then I will simply remove them, because we don't need the imported ontologies
+## .downloadPsiObo <- function(){
+## 		connPsiObo <- url("http://psidev.cvs.sourceforge.net/viewvc/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo")
+## 		oboFile <- readLines(connPsiObo)
+## 		close(connPsiObo)
+## 		oboFile <- oboFile[-grep("import:",oboFile)] 
+## 		connLocal <- file("psi-ms.obo")
+## 		writeLines(oboFile,connLocal)
+## 		close(connLocal)
+## }
 
-# Checks if the psi-ms.obo is there
-# Will be converted to "checkforinstruments" as soon as I can find the problem
-# with getOntology()
-.checkForPsiMs <- function(){
+## # Checks if the psi-ms.obo is there
+## # Will be converted to "checkforinstruments" as soon as I can find the problem
+## # with getOntology()
+## .checkForPsiMs <- function(){
 	
-	if(file.exists("psi-ms.obo")){
-		if(.isOboReadable("psi-ms.obo")){
-			print("It seems that you have a working psi-ms.obo, do you want to update it? [y/n]")
-			while(TRUE){
-				answer <- readLines(stdin(), n=1, warn=FALSE)
-				if(answer == "y"){
-					.downloadPsiObo()
-					return(TRUE)
-				}
-				if(answer == "n"){
-					return(TRUE)
-				}
-				print("Please type exactly y or n")
-			}
-		}
-	}
-	.downloadPsiObo()
-	return(TRUE)
-}
+## 	if(file.exists("psi-ms.obo")){
+## 		if(.isOboReadable("psi-ms.obo")){
+## 			print("It seems that you have a working psi-ms.obo, do you want to update it? [y/n]")
+## 			while(TRUE){
+## 				answer <- readLines(stdin(), n=1, warn=FALSE)
+## 				if(answer == "y"){
+## 					.downloadPsiObo()
+## 					return(TRUE)
+## 				}
+## 				if(answer == "n"){
+## 					return(TRUE)
+## 				}
+## 				print("Please type exactly y or n")
+## 			}
+## 		}
+## 	}
+## 	.downloadPsiObo()
+## 	return(TRUE)
+## }
 
-# This is a list of the possible instrument names 
-.getInstruments <- function(){
-	Onto <- ontoCAT::getOntology(system.file(package = "RMassBank", "psi-ms.obo"))
-	instrumentTerms <- ontoCAT::getAllTermChildrenById(Onto,"MS_1000031")
-	instruments <- vector()	
-	for(i in 1:length(instrumentTerms)){
-		instruments[i] <- ontoCAT::getLabel(instrumentTerms[[i]])
-	}
-	return(instruments)
-}
+## # This is a list of the possible instrument names 
+## .getInstruments <- function(){
+## 	Onto <- ontoCAT::getOntology(system.file(package = "RMassBank", "psi-ms.obo"))
+## 	instrumentTerms <- ontoCAT::getAllTermChildrenById(Onto,"MS_1000031")
+## 	instruments <- vector()	
+## 	for(i in 1:length(instrumentTerms)){
+## 		instruments[i] <- ontoCAT::getLabel(instrumentTerms[[i]])
+## 	}
+## 	return(instruments)
+## }
 
 #' Calculate the mass from a SMILES-String
 #' 

--- a/R/validateMassBank.R
+++ b/R/validateMassBank.R
@@ -23,7 +23,6 @@ validate <- function(path, simple = TRUE) {
 
 	# Is the argument a directory?
 	# If yes, list the files
-	RMassBank.env$Instrument_List <- "NO_INSTRUMENT_LIST_AFTER_ONTOCAT_REMOVAL"
 	RMassBank.env$testnumber <- 1
 	if(file.info(path[1])$isdir){
 	    Files <- list.files(path = path,
@@ -88,68 +87,6 @@ validate <- function(path, simple = TRUE) {
 	}
 	print(paste("Report for the file(s) finished"))
 }
-
-## # This function checks if an .obo-file is readable for ontoCAT
-## .isOboReadable <- function(filename){
-
-## 	# getOntology() has a problem with reading relative Windows paths(it wants an URI),
-## 	# so the path has to be made absolute
-## 	# I reckon this should work under Linux without doing that
-## 	ont <- ontoCAT::getOntology(normalizePath(filename))
-## 	if(is.null(ontoCAT::getOntologyAccession(ont))){
-## 		return(FALSE)
-## 	}
-## 	return(TRUE)
-## }
-
-## # This function downloads the psi-ms.obo-ontology so we can get the allowed instrument-names
-## # This is a _temporary_ fix until I find out why getOntology() doesn't work when there are "import:"-lines in the .obo-file
-## # Until then I will simply remove them, because we don't need the imported ontologies
-## .downloadPsiObo <- function(){
-## 		connPsiObo <- url("http://psidev.cvs.sourceforge.net/viewvc/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo")
-## 		oboFile <- readLines(connPsiObo)
-## 		close(connPsiObo)
-## 		oboFile <- oboFile[-grep("import:",oboFile)] 
-## 		connLocal <- file("psi-ms.obo")
-## 		writeLines(oboFile,connLocal)
-## 		close(connLocal)
-## }
-
-## # Checks if the psi-ms.obo is there
-## # Will be converted to "checkforinstruments" as soon as I can find the problem
-## # with getOntology()
-## .checkForPsiMs <- function(){
-	
-## 	if(file.exists("psi-ms.obo")){
-## 		if(.isOboReadable("psi-ms.obo")){
-## 			print("It seems that you have a working psi-ms.obo, do you want to update it? [y/n]")
-## 			while(TRUE){
-## 				answer <- readLines(stdin(), n=1, warn=FALSE)
-## 				if(answer == "y"){
-## 					.downloadPsiObo()
-## 					return(TRUE)
-## 				}
-## 				if(answer == "n"){
-## 					return(TRUE)
-## 				}
-## 				print("Please type exactly y or n")
-## 			}
-## 		}
-## 	}
-## 	.downloadPsiObo()
-## 	return(TRUE)
-## }
-
-## # This is a list of the possible instrument names 
-## .getInstruments <- function(){
-## 	Onto <- ontoCAT::getOntology(system.file(package = "RMassBank", "psi-ms.obo"))
-## 	instrumentTerms <- ontoCAT::getAllTermChildrenById(Onto,"MS_1000031")
-## 	instruments <- vector()	
-## 	for(i in 1:length(instrumentTerms)){
-## 		instruments[i] <- ontoCAT::getLabel(instrumentTerms[[i]])
-## 	}
-## 	return(instruments)
-## }
 
 #' Calculate the mass from a SMILES-String
 #' 

--- a/inst/validationTests/runit.MS2.instruments.R-disabled
+++ b/inst/validationTests/runit.MS2.instruments.R-disabled
@@ -1,4 +1,0 @@
-test.instrumentname <- function(){
-	Instrument_Name <- RMassBank.env$mb[[RMassBank.env$testnumber]]@compiled_ok[[1]][['AC$INSTRUMENT']]
-	checkTrue(Instrument_Name %in% RMassBank.env$Instrument_List)
-}


### PR DESCRIPTION
Since ontoCAT is about to be removed from BioC, this work removes 
the validation code depending on it. In particular, we don't check 
anymore that the instrument name is in PSI-MS.obo ontology. 