### PR TITLE
Do not write out empty PUBLICATION tags.

### DIFF
--- a/R/createMassBank.R
+++ b/R/createMassBank.R
@@ -1114,7 +1114,9 @@ readMbdata <- function(row)
   mbdata[['AUTHORS']] <- getOption("RMassBank")$annotations$authors
   mbdata[['LICENSE']] <- getOption("RMassBank")$annotations$license
   mbdata[['COPYRIGHT']] <- getOption("RMassBank")$annotations$copyright
-  mbdata[['PUBLICATION']] <- getOption("RMassBank")$annotations$publication
+  if(getOption("RMassBank")$annotations$publication!="") {
+    mbdata[['PUBLICATION']] <- getOption("RMassBank")$annotations$publication
+  }
   
   # Read all determined fields from the file
   # This is not very flexible, as you can see...


### PR DESCRIPTION
Currently RMassBank is writing out empty tags if no data is provided. This breaks validation because empty tags are not defined in https://github.com/MassBank/MassBank-web/blob/master/Documentation/MassBankRecordFormat.md.