### PR TITLE
Fix mzR import after mzR::header reporting NA for missing data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RMassBank
 Type: Package
 Title: Workflow to process tandem MS files and build MassBank records
-Version: 2.11.4
+Version: 2.11.5
 Authors@R: c(
     person(given = "RMassBank at Eawag", email = "massbank@eawag.ch",
     role=c("cre")),

--- a/R/leMsmsRaw.R
+++ b/R/leMsmsRaw.R
@@ -198,14 +198,14 @@ findMsMsHR.mass <- function(msRaw, mz, limit.coarse, limit.fine, rtLimits = NA, 
 		headerData[which(headerData$msLevel == 1),"precursorScanNum"] <- 0
 	}
 	# bugfix 201803: PRM scans that were performed before the first full scan (found in some files)
-	headerData <- headerData[
-	  !((headerData$msLevel == 2) & (headerData$precursorScanNum == 0)),,drop=FALSE
-	]
+	headerData <- headerData[!((headerData$msLevel == 2) &
+                                   (is.na(headerData$precursorScanNum))),,
+                                 drop = FALSE]
 	# Find MS2 spectra with precursors which are in the allowed 
-	# scan filter (coarse limit) range
-	findValidPrecursors <- headerData[
-			(headerData$precursorMZ > mz - limit.coarse) &
-					(headerData$precursorMZ < mz + limit.coarse),]
+	# scan filter (coarse limit) range; which to get rid of NAs
+	findValidPrecursors <- headerData[which(
+            headerData$precursorMZ > (mz - limit.coarse) &
+            headerData$precursorMZ < (mz + limit.coarse)), ]
 	# Find the precursors for the found spectra
 	validPrecursors <- unique(findValidPrecursors$precursorScanNum)
 	# check whether the precursors are real: must be within fine limits!
@@ -245,9 +245,11 @@ findMsMsHR.mass <- function(msRaw, mz, limit.coarse, limit.fine, rtLimits = NA, 
 	spectra <- lapply(eic$scan, function(masterScan)
 			{
 				masterHeader <- headerData[headerData$acquisitionNum == masterScan,]
-				childHeaders <- headerData[(headerData$precursorScanNum == masterScan) 
-								& (headerData$precursorMZ > mz - limit.coarse) 
-								& (headerData$precursorMZ < mz + limit.coarse) ,]
+				childHeaders <- headerData[
+                                    which(headerData$precursorScanNum == masterScan 
+                                          & headerData$precursorMZ > (mz - limit.coarse) 
+                                          & headerData$precursorMZ < (mz + limit.coarse)) , ,
+                                    drop = FALSE]
 				
 				# Fix 9.10.17: headers now include non-numeric columns, leading to errors in data conversion.
 				# Remove non-numeric columns

--- a/R/msmsRawExtensions.r
+++ b/R/msmsRawExtensions.r
@@ -62,8 +62,8 @@ findMsMsHR.ticms2 <- function(msRaw, mz, limit.coarse, limit.fine, rtLimits = NA
   # Find MS2 spectra with precursors which are in the allowed 
   # scan filter (coarse limit) range
   findValidPrecursors <- headerData[
-      (headerData$precursorMZ > mz - limit.coarse) &
-          (headerData$precursorMZ < mz + limit.coarse),]
+      which(headerData$precursorMZ > (mz - limit.coarse) &
+            headerData$precursorMZ < (mz + limit.coarse)),]
   # Find the precursors for the found spectra
   
   
@@ -94,10 +94,12 @@ findMsMsHR.ticms2 <- function(msRaw, mz, limit.coarse, limit.fine, rtLimits = NA
         ret$parentHeader[1,4:20] <- 0
         ret$parentHeader[1,6] <- NA
 
-        childHeaders <- headerData[(headerData$acquisitionNum == masterScan) 
-                & (headerData$precursorMZ > mz - limit.coarse) 
-                & (headerData$precursorMZ < mz + limit.coarse) ,]
-        
+        childHeaders <- headerData[
+            which(headerData$acquisitionNum == masterScan 
+                  & headerData$precursorMZ > (mz - limit.coarse) 
+                  & headerData$precursorMZ < (mz + limit.coarse)), ,
+            drop = FALSE]
+      
         childScans <- childHeaders$acquisitionNum
         ret$parentScan <- min(childScans)-1
 		ret$parentHeader[1,1:3] <- min(childScans)-1


### PR DESCRIPTION
- Fix the mzR import functionality to match the changes in recent mzR::header
  reporting `NA` instead of `0` for not set/available spectra variables.

Unfortunatelly I do not have a working texlive installation on my test machine, so I could not check if the package builds cleanly (i.e. the vignettes).