### PR TITLE
Inclusion of scan range in record format

### DIFF
--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -266,10 +266,10 @@ setMethod("buildRecord", "RmbSpectrum2", function(o, ..., cpd = NULL, mbdata = l
 	# Add scan range to AC$MS, if present
 	if (all(c("scanWindowUpperLimit", "scanWindowLowerLimit") %in%
 	  names(spectrum@info))) {
-		ac_ms[['MS_SCAN_LOWER_LIMIT']] <-
-		  spectrum@info$scanWindowLowerLimit
-		ac_ms[['MS_SCAN_UPPER_LIMIT']] <-
-		  spectrum@info$scanWindowUpperLimit
+		ac_ms[['SCAN_RANGE_M/Z']] <- paste(
+		  spectrum@info$scanWindowLowerLimit,
+		  spectrum@info$scanWindowUpperLimit,
+		  sep='-')
 	}
 
 	# Create the "lower part" of the record.  

--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -266,7 +266,7 @@ setMethod("buildRecord", "RmbSpectrum2", function(o, ..., cpd = NULL, mbdata = l
 	# Add scan range to AC$MS, if present
 	if (all(c("scanWindowUpperLimit", "scanWindowLowerLimit") %in%
 	  names(spectrum@info))) {
-		ac_ms[['SCAN_RANGE_M/Z']] <- paste(
+		ac_ms[['MASS_RANGE_M/Z']] <- paste(
 		  spectrum@info$scanWindowLowerLimit,
 		  spectrum@info$scanWindowUpperLimit,
 		  sep='-')

--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -263,6 +263,14 @@ setMethod("buildRecord", "RmbSpectrum2", function(o, ..., cpd = NULL, mbdata = l
 			ms_fi[['PRECURSOR_INTENSITY']] <- spectrum@precursorIntensity
 	}
 
+	# Add scan range to AC$MS, if present
+	if (all(c("scanWindowUpperLimit", "scanWindowLowerLimit") %in%
+	  names(spectrum@info))) {
+		ac_ms[['MS_SCAN_LOWER_LIMIT']] <-
+		  spectrum@info$scanWindowLowerLimit
+		ac_ms[['MS_SCAN_UPPER_LIMIT']] <-
+		  spectrum@info$scanWindowUpperLimit
+	}
 
 	# Create the "lower part" of the record.  
 

--- a/R/leMsMs.r
+++ b/R/leMsMs.r
@@ -146,12 +146,6 @@ msmsWorkflow <- function(w, mode="pH", steps=c(1:8), confirmMode = FALSE, newRec
         }
 	  pb <- do.call(progressbar, list(object=NULL, value=0, min=0, max=nLen))
 	  w@spectra <- as(lapply(w@spectra, function(spec) {
-				  #print(spec$id)
-                        # if(findLevel(spec@id,TRUE) == "unknown"){
-                            # analyzeMethod <- "intensity"
-                        # } else {
-                            # analyzeMethod <- "formula"
-                        # }
                         s <- analyzeMsMs(msmsPeaks = spec, mode=mode, detail=TRUE, run="preliminary",
 						  filterSettings = settings$filterSettings,
 						  spectraList = settings$spectraList, method = analyzeMethod)
@@ -492,7 +486,7 @@ analyzeMsMs <- function(msmsPeaks, mode="pH", detail=FALSE, run="preliminary",
 	# merged together with all the combine / pack stuff.
 	children <- mapply(function(spec, info)
 			{
-				spec@info <- info
+				spec@info <- c(info, spec@info)
 				spec
 			}, r@children, spectraList, SIMPLIFY=FALSE)
 	r@children <- as(children, "SimpleList")


### PR DESCRIPTION
Scan ranges are now parsed from `.MZml` files (if present) and included in the record format as a new subtag:
`AC$MASS_SPECTROMETRY: MASS_RANGE_M/Z min-max`
See the [record format specification](https://github.com/MassBank/MassBank-web/blob/main/Documentation/MassBankRecordFormat.md#245-subtag-mass_range_mz)
This addresses #216
