### PR TITLE
Project tag inclusion

### DIFF
--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -357,9 +357,14 @@ setMethod("buildRecord", "RmbSpectrum2", function(o, ..., cpd = NULL, mbdata = l
 	# Generate the title and then delete the temprary RECORD_TITLE_CE field used before
 	mbdata[["RECORD_TITLE"]] <- .parseTitleString(mbdata)
 	mbdata[["RECORD_TITLE_CE"]] <- NULL
-	# Calculate the accession number from the options.
 	userSettings = getOption("RMassBank")
-	# Use a user-defined accessionBuilder, if present
+	# Include project tag, if present
+	if("project" %in% names(userSettings))
+	{
+		mbdata[["PROJECT"]] <- userSettings$project
+	}
+	# Use 'simple', 'standard' or 'selfDefined' accessionBuilder
+	# depending on user input
 	if("accessionBuilderType" %in% names(userSettings))
 	{
 		assert_that(userSettings$accessionBuilderType %in% c(

--- a/vignettes/RMassBank.Rmd
+++ b/vignettes/RMassBank.Rmd
@@ -152,6 +152,7 @@ should then be edited. Important settings are:
     for generating MassBank record accession numbers. This will be used if `accessionBuilderType` is unspecified or "standard" (see `accessionBuilderType` above).
 *  `accessionBuilderFile`: A file with a user-defined function to generate MassBank record accession numbers. This will be used if `accessionBuilderType` is "selfDefined" (see `accessionBuilderType` above.)
 *  `accessionNumberStart`: An integer < 1000000 defining the starting point of MassBank record accession numbers. This will be used if `accessionBuilderType` is "simple". (see `accessionBuilderType` above).
+*  `project`: A string giving the project tag, optional. If present, this will be inclueded in the `PROJECT` field of the record.
 *  `recalibrateBy`: Which parameter to use for recalibration:
     `dppm` (recalibrate the deviation in ppm) or `dmz`
     (recalibrate the m/z deviation).


### PR DESCRIPTION
The project tag can now be added in an optional field `project` of the settings file. A given project name will be copied to the new field `PROJECT` of the record. This behaviour is also documented in the `RMassBank.Rmd` vignette.
This addresses #192
