### PR TITLE
Creating more flexible structure in AC$CHROMATOGRAPHY to allow for third SOLVENT

### DIFF
--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -153,8 +153,11 @@ getAnalyticalInfo <- function(cpd = NULL)
 	ac_lc[['FLOW_GRADIENT']] <- getOption("RMassBank")$annotations$lc_gradient
 	ac_lc[['FLOW_RATE']] <- getOption("RMassBank")$annotations$lc_flow
 	ac_lc[['RETENTION_TIME']] <- sprintf("%.3f min", rt)  
-	ac_lc[['SOLVENT A']] <- getOption("RMassBank")$annotations$lc_solvent_a
-	ac_lc[['SOLVENT B']] <- getOption("RMassBank")$annotations$lc_solvent_b
+	lc_solvents <- getOption("RMassBank")$annotations$lc_solvents
+	ac_lc[['SOLVENT A']] <- lc_solvents$lc_solvent_a
+	ac_lc[['SOLVENT B']] <- lc_solvents$lc_solvent_b
+	if(length(lc_solvents) > 2)
+		ac_lc[['SOLVENT C']] <- lc_solvents$lc_solvent_c
 	
 	# Treutler fixes for custom properties, trying to forwardport this here
 	

--- a/R/buildRecord.R
+++ b/R/buildRecord.R
@@ -162,14 +162,19 @@ getAnalyticalInfo <- function(cpd = NULL)
 	# Treutler fixes for custom properties, trying to forwardport this here
 	
 	## add generic AC$MASS_SPECTROMETRY information
-	properties      <- names(getOption("RMassBank")$annotations)
-	presentProperties <- names(ac_ms)#c('MS_TYPE', 'IONIZATION', 'ION_MODE')#, 'FRAGMENTATION_MODE', 'COLLISION_ENERGY', 'RESOLUTION')
+	# Note: For whatever reason, recursivity is inverted for the unlist
+	# function, meaning that recursive=FALSE actually leads to the
+	# behaviour expected when setting recursive=TRUE, which is desired
+	# here, because nested lists exist. See help(unlist)
+	properties <- names(unlist(getOption("RMassBank")$annotations,
+	  recursive=FALSE))
+	presentProperties <- names(ac_ms)
 	
 	theseProperties <- grepl(x = properties, pattern = "^AC\\$MASS_SPECTROMETRY_")
 	properties2     <- gsub(x = properties, pattern = "^AC\\$MASS_SPECTROMETRY_", replacement = "")
 	theseProperties <- theseProperties & !(properties2 %in% presentProperties)
-	theseProperties <- theseProperties & (unlist(getOption("RMassBank")$annotations) != "NA")
-	ac_ms[properties2[theseProperties]] <- unlist(getOption("RMassBank")$annotations[theseProperties])
+	theseProperties <- theseProperties & (unlist(getOption("RMassBank")$annotations, recursive=FALSE) != "NA")
+	ac_ms[properties2[theseProperties]] <- unlist(getOption("RMassBank")$annotations, recursive=FALSE)[theseProperties]
 	
 	## add generic AC$CHROMATOGRAPHY information
 	#properties      <- names(getOption("RMassBank")$annotations)
@@ -177,8 +182,8 @@ getAnalyticalInfo <- function(cpd = NULL)
 	properties2     <- gsub(x = properties, pattern = "^AC\\$CHROMATOGRAPHY_", replacement = "")
 	presentProperties <- names(ac_lc)#c('COLUMN_NAME', 'FLOW_GRADIENT', 'FLOW_RATE', 'RETENTION_TIME', 'SOLVENT A', 'SOLVENT B')
 	theseProperties <- theseProperties & !(properties2 %in% presentProperties)
-	theseProperties <- theseProperties & (unlist(getOption("RMassBank")$annotations) != "NA")
-	ac_lc[properties2[theseProperties]] <- unlist(getOption("RMassBank")$annotations[theseProperties])
+	theseProperties <- theseProperties & (unlist(getOption("RMassBank")$annotations, recursive=FALSE) != "NA")
+	ac_lc[properties2[theseProperties]] <- unlist(getOption("RMassBank")$annotations, recursive=FALSE)[theseProperties]
 	
 
 	

--- a/inst/RMB_options.ini
+++ b/inst/RMB_options.ini
@@ -52,9 +52,10 @@ annotations:
     lc_gradient: 
     # example: lc_flow: 200 uL/min
     lc_flow: 
-    # example: lc_solvent_a: water with 0.1% formic acid
-    lc_solvent_a: 
-    lc_solvent_b: 
+    lc_solvents:
+        # example: lc_solvent_a: water with 0.1% formic acid
+        lc_solvent_a: 
+        lc_solvent_b: 
     # example: lc_column: XBridge C18 3.5um, 2.1x50mm, Waters
     lc_column: 
     # Prefix for MassBank accession IDs


### PR DESCRIPTION
For compliance with the record format and better flexibility, users should be able to add a third `SOLVENT` in `AC$CHROMATOGRAPHY`. The issue is described in #176
