### PR TITLE
Resolved a warning regarding replacement functions

### DIFF
--- a/R/Generics.R
+++ b/R/Generics.R
@@ -40,4 +40,4 @@ setGeneric("selectPeaks", function(o, ...) standardGeneric("selectPeaks"))
 setGeneric("addProperty", function(o, name, type, value=NA) standardGeneric("addProperty"))
 
 setGeneric("property", function(o, property) standardGeneric("property"))
-setGeneric("property<-", function(o, property, value, addNew = FALSE, class="") standardGeneric("property<-"))
+setGeneric("property<-", function(o, property, addNew = FALSE, class="", value) standardGeneric("property<-"))

--- a/R/SpectrumMethods.R
+++ b/R/SpectrumMethods.R
@@ -300,7 +300,7 @@ setMethod("property", c("RmbSpectrum2", "character"), function(o, property)
 		})
 
 
-.propertySet <- function(o, property, value, addNew = FALSE, class="")
+.propertySet <- function(o, property, addNew = FALSE, class="", value)
 {
 	if(class == "") class <- class(value)
 	if(!(property %in% colnames(o@properties)) & !addNew)
@@ -314,14 +314,18 @@ setMethod("property", c("RmbSpectrum2", "character"), function(o, property)
 	return(o)
 }
 
+
 #' @export
-setMethod("property<-", c("RmbSpectrum2", "character", "ANY", "logical", "character"), .propertySet )
+setMethod("property<-", signature(o="RmbSpectrum2", property="character", addNew="logical", class="character", value="ANY"), .propertySet )
+
 #' @export
-setMethod("property<-", c("RmbSpectrum2", "character", "ANY", "missing", "character"), .propertySet )
+setMethod("property<-", signature(o="RmbSpectrum2", property="character", addNew="missing", class="character", value="ANY"), .propertySet )
+
 #' @export
-setMethod("property<-", c("RmbSpectrum2", "character", "ANY", "logical", "missing"), .propertySet)
+setMethod("property<-", signature(o="RmbSpectrum2", property="character", addNew="logical", class="missing", value="ANY"), .propertySet)
+
 #' @export
-setMethod("property<-", c("RmbSpectrum2", "character", "ANY", "missing", "missing"), .propertySet )
+setMethod("property<-", signature(o="RmbSpectrum2", property="character", addNew="missing", class="missing", value="ANY"), .propertySet )
 
 
 .fillSlots <- function(o, slotNames)
@@ -333,3 +337,4 @@ setMethod("property<-", c("RmbSpectrum2", "character", "ANY", "missing", "missin
   }
   return(o)
 }
+


### PR DESCRIPTION
I changed the argument order in `.propertySet` and in the corresponding `setGeneric` and `setMethod` calls. This was done to resolve a warning and, according to my tests, doesn't introduce any new problems.
